### PR TITLE
Update Swift.stg

### DIFF
--- a/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
+++ b/org/antlr/v4/tool/templates/codegen/Swift/Swift.stg
@@ -702,7 +702,7 @@ if (<if(invert)><m.varName> \<= 0 || <else>!<endif>(<expr>)) {
 
 Wildcard(w) ::= <<
 setState(<w.stateNumber>)
-<if(w.labels)><w.labels:{l | <labelref(l)> = }><endif>matchWildcard();
+<if(w.labels)><w.labels:{l | <labelref(l)> = }><endif>try matchWildcard();
 >>
 
 // ACTION STUFF


### PR DESCRIPTION
using of wildcards lead to a swift compile error due to a missing `try`